### PR TITLE
fix: Mapbox Android 11.3.1

### DIFF
--- a/.github/workflows/android-lib.yml
+++ b/.github/workflows/android-lib.yml
@@ -20,6 +20,7 @@ on:
         - io.coil-kt:coil:2.0.0
         - org.slf4j:slf4j-api:1.7.24
         - org.jetbrains.kotlin:kotlin-parcelize-runtime:1.6.10
+        - com.mapbox.mapboxsdk:mapbox-sdk-geojson:6.9.0
         - com.mapbox.maps:android:11.3.1
         - io.socket:socket.io-client:2.0.1
         - org.mp4parser:muxer:1.9.56

--- a/.github/workflows/android-lib.yml
+++ b/.github/workflows/android-lib.yml
@@ -10,7 +10,7 @@ on:
         options:
           - '7.0.404'
           - '8.0.204'
-        default: '7.0.404'
+        default: '8.0.204'
       LIB_ARTIFACT:
         description: 'Android library to publish'
         required: true

--- a/bind.sh
+++ b/bind.sh
@@ -1,5 +1,6 @@
 
 rm -rf ./src/libs/BindingHost/*.props
+# dotnet nuget locals -c all
 dotnet tool restore
 dotnet clean ./src/libs/BindingHost/BindingHost.csproj
 

--- a/build.cake
+++ b/build.cake
@@ -8,7 +8,7 @@ using System.Xml;
 using System.Xml.Linq;
 
 var ARTIFACT = Argument<string>("artifact");
-var DOTNET_VERSION = Argument<string>("dotnet", "7.0");
+var DOTNET_VERSION = Argument<string>("dotnet", "8.0");
 var TASK = Argument<string>("task", Argument<string>("t", "Default"));
 
 

--- a/src/Project.net8.cshtml
+++ b/src/Project.net8.cshtml
@@ -6,7 +6,7 @@
   var licensePath = "LICENSE";
   var assemblyVersion = Model.Artifact.AssemblyVersion;
 }
-<Project Sdk="Xamarin.Legacy.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Target Name="_CleanAarOutputPath" AfterTargets="_CreateAar" BeforeTargets="_IncludeAarInNuGetPackage">
     <Delete Files="$(_AarOutputPath)" />
   </Target>
@@ -129,32 +129,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Additions\" />
-    <Folder Include="Jars\" />
-    <Folder Include="Transforms\" />
-  </ItemGroup>
-  <ItemGroup>
-    @* <Compile Include="..\..\..\..\src\AssemblyInfo.cs" /> *@
-  </ItemGroup>
-
-  <ItemGroup>
-    <TransformFile Include="Transforms\*.xml" />
-  </ItemGroup>
-  <ItemGroup>
   @if (!string.IsNullOrEmpty(Model.Artifact.SourcesJarRelativeFilePath)) {
     <JavaSourceJar
-          Include="$(UserHome)/@(Model.Artifact.SourcesJarRelativeFilePath)"
-          Condition="Exists('$(UserHome)/@(Model.Artifact.SourcesJarRelativeFilePath)')"
-          />
+      Include="$(UserHome)/@(Model.Artifact.SourcesJarRelativeFilePath)"
+      Condition="Exists('$(UserHome)/@(Model.Artifact.SourcesJarRelativeFilePath)')"
+      />
   }
-  @* https://github.com/xamarin/java.interop/issues/1028#issuecomment-1222895957
-  @if (!string.IsNullOrEmpty(Model.Artifact.JavadocJarRelativeFilePath)) {
-    <JavaDocJar
-          Include="$(UserHome)/@(Model.Artifact.JavadocJarRelativeFilePath)"
-          Condition="Exists('$(UserHome)/@(Model.Artifact.JavadocJarRelativeFilePath)')"
-          />
-  } *@
-  </ItemGroup>
 @{
   var homeFolder = Xamarin.Build.Download.Platform.IsWindows
                   ? System.Environment.SpecialFolder.LocalApplicationData
@@ -165,33 +145,11 @@
     Model.Artifact.ProguardFileRelativePath
   );
 }
-  <ItemGroup>
 @if (!string.IsNullOrEmpty(Model.Artifact.ProguardFileRelativePath)
   && System.IO.File.Exists(proguardFilePath)) {
     <None Include="@(proguardFilePath)" Pack="True" PackagePath="proguard" />
-  }  
-  </ItemGroup>
-
-@* <ItemGroup>
-  @if (Model.Config.MvnRepositories?.Count > 0) {
-    foreach (var kvp in Model.Config.MvnRepositories) {
-    <GradleRepository Include="@kvp.Key">
-      <Repository>
-      @Raw(@kvp.Value)
-      </Repository>
-    </GradleRepository>
-    }
-  }
-  @if (Model.NuGetDependencies?.Count > 0) {
-    foreach (var dep in Model.NuGetDependencies) {
-    <GradleImplementation 
-      Include="@(dep.GradleImplementation)" />
-    }
-  }
-</ItemGroup> *@
-
-  <ItemGroup>
-      @if (Model.Artifact.IsAAR) {
+}
+@if (Model.Artifact.IsAAR) {
     <InputJar Include="$(UserHome)/@(Model.Artifact.LibFolderPath)/_aar/classes.jar" />
     <!-- For those artifacts with lib/ folder -->
     <InputJar
@@ -201,22 +159,18 @@
       } else if (!string.IsNullOrEmpty(Model.Artifact.LibRelativePath)) {
     <InputJar Include="$(UserHome)/@(Model.Artifact.LibRelativePath)" />
       }
-  </ItemGroup>
-  <ItemGroup>
     @foreach (var dep in @Model.NuGetDependencies) {
       if (!dep.Nuget.DependencyOnly) {
-        <ProjectReference Include="..\..\..\@(dep.Group.Id)\@(dep.Nuget.ArtifactId)\binding\@(dep.Nuget.PackageId).csproj" PrivateAssets="none" />
+    <ProjectReference Include="..\..\..\@(dep.Group.Id)\@(dep.Nuget.ArtifactId)\binding\@(dep.Nuget.PackageId).csproj" PrivateAssets="none" />
       }
     }
-  </ItemGroup>
-  <ItemGroup>
     @foreach (var dep in @Model.NuGetDependencies) {
       if (dep.Nuget.DependencyOnly) {
-      <PackageReference Include="@(dep.Nuget.PackageId)" Version="@(dep.Version.NugetVersion.ToNormalizedString())" PrivateAssets="none" />
+    <PackageReference Include="@(dep.Nuget.PackageId)" Version="@(dep.Version.NugetVersion.ToNormalizedString())" PrivateAssets="none" />
       }
     }
     @foreach (var dep in @Model.Artifact.FixedVersions) {
-      <PackageReference Include="@(dep.Key)" Version="@(dep.Value)" PrivateAssets="none" />
+    <PackageReference Include="@(dep.Key)" Version="@(dep.Value)" PrivateAssets="none" />
     }
   </ItemGroup>
   <ItemGroup>
@@ -225,5 +179,4 @@
       <Link>Transforms/Metadata.common.xml</Link>
     </TransformFile>
   </ItemGroup>
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/src/android/com.mapbox.base/annotations/0.11.0.json
+++ b/src/android/com.mapbox.base/annotations/0.11.0.json
@@ -1,4 +1,5 @@
 {
-  "revision": 0,
+  "revision": 1,
+  "nugetVersion": "0.11.0.1",
   "runtimeDependenciesAsCompile": true
 }

--- a/src/android/com.mapbox.base/annotations/nuget.json
+++ b/src/android/com.mapbox.base/annotations/nuget.json
@@ -1,7 +1,7 @@
 {
   "packageId": "Com.Mapbox.Base.Annotations",
   "name": "annotations",
-  "dependencyOnly": true,
+  "dependencyOnly": false,
   "dotnet8": false,
   "versionMappings": []
 }

--- a/src/android/com.mapbox.base/common/0.11.0.json
+++ b/src/android/com.mapbox.base/common/0.11.0.json
@@ -1,4 +1,5 @@
 {
-  "revision": 0,
+  "revision": 1,
+  "nugetVersion": "0.11.0.1",
   "runtimeDependenciesAsCompile": true
 }

--- a/src/android/com.mapbox.base/common/nuget.json
+++ b/src/android/com.mapbox.base/common/nuget.json
@@ -1,7 +1,7 @@
 {
   "packageId": "Com.Mapbox.Base.Common",
   "name": "common",
-  "dependencyOnly": true,
+  "dependencyOnly": false,
   "dotnet8": false,
   "versionMappings": []
 }

--- a/src/android/com.mapbox.base/group.json
+++ b/src/android/com.mapbox.base/group.json
@@ -2,5 +2,6 @@
   "name": "Mapbox",
   "homePageUrl": "https://docs.mapbox.com/android/maps/guides/",
   "guideUrl": "https://mapbox.tuyen-vuduc.tech/",
+  "dotnet8": true,
   "runtimeDependenciesAsCompile": true
 }

--- a/src/android/com.mapbox.base/maven.props
+++ b/src/android/com.mapbox.base/maven.props
@@ -1,0 +1,27 @@
+<Project>
+  <ItemGroup>
+    <AndroidNamespaceReplacement Include='Com.Mapbox.Maps.Plugin' Replacement='Com.Mapbox.Maps.Plugins' Visible="false" />
+    <AndroidNamespaceReplacement Include='Com.Mapbox.Maps.Plugins.Attribution' Replacement='Com.Mapbox.Maps.Plugins.Attributions' Visible="false" />
+    <AndroidNamespaceReplacement Include='Com.Mapbox.Maps.Annotation' Replacement='Com.Mapbox.Maps.Annotations' Visible="false" />
+    <AndroidNamespaceReplacement Include='Com.Mapbox.Maps.Plugins.Annotation' Replacement='Com.Mapbox.Maps.Plugins.Annotations' Visible="false" />
+  </ItemGroup>    
+  <ItemGroup>
+    <GradleRepository Include="https://api.mapbox.com/downloads/v2/releases/maven">
+      <Repository>
+      maven {
+        url 'https://api.mapbox.com/downloads/v2/releases/maven'
+        authentication {
+          basic(BasicAuthentication)
+        }
+        credentials {
+          // Do not change the username below.
+          // This should always be `mapbox` (not your username).
+          username = "mapbox"
+          // Use the secret token you stored in gradle.properties as the password
+          password = providers.gradleProperty("MAPBOX_DOWNLOADS_TOKEN").get()
+        }
+      }
+      </Repository>
+    </GradleRepository>
+  </ItemGroup>
+</Project>

--- a/src/android/com.mapbox.common/common/24.3.1.fixed.json
+++ b/src/android/com.mapbox.common/common/24.3.1.fixed.json
@@ -1,6 +1,8 @@
 {
-    "Xamarin.AndroidX.Annotation": "1.7.1.1",
-    "Xamarin.Kotlin.StdLib.Jdk8": "1.9.10.2",
-    "Xamarin.KotlinX.Coroutines.Core.Jvm": "1.6.4.3",
-    "Xamarin.Kotlin.StdLib.Common": "1.9.10.2"
+    "Xamarin.Kotlin.StdLib.Common": "1.9.21.1",
+    "Xamarin.GooglePlayServices.Tasks": "118.1.0.1",
+    "Xamarin.AndroidX.Annotation": "1.7.1.2",
+    "Xamarin.AndroidX.Core": "1.12.0.3",
+    "Xamarin.Kotlin.StdLib.Jdk8": "1.9.21.1",
+    "Xamarin.KotlinX.Coroutines.Core.Jvm": "1.7.3.3"   
 }

--- a/src/android/com.mapbox.common/common/24.3.1.json
+++ b/src/android/com.mapbox.common/common/24.3.1.json
@@ -1,4 +1,5 @@
 {
-  "revision": 0,
+  "revision": 1,
+  "nugetVersion": "24.3.1.1",
   "runtimeDependenciesAsCompile": true
 }

--- a/src/android/com.mapbox.common/common/binding/Transforms/Metadata.xml
+++ b/src/android/com.mapbox.common/common/binding/Transforms/Metadata.xml
@@ -1,3 +1,4 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <metadata>
+  <remove-node path="/api/package[@name='com.mapbox.common.location']/class[@name='GoogleDeviceLocationProviderKt']/method[@name='getGooglePlayServicesHelper' and count(parameter)=0]" />
 </metadata>

--- a/src/android/com.mapbox.common/common/nuget.json
+++ b/src/android/com.mapbox.common/common/nuget.json
@@ -1,7 +1,7 @@
 {
   "packageId": "Com.Mapbox.Common.Common",
   "name": "common",
-  "dependencyOnly": true,
+  "dependencyOnly": false,
   "dotnet8": false,
   "versionMappings": []
 }

--- a/src/android/com.mapbox.common/group.json
+++ b/src/android/com.mapbox.common/group.json
@@ -2,5 +2,6 @@
   "name": "Mapbox",
   "homePageUrl": "https://docs.mapbox.com/android/maps/guides/",
   "guideUrl": "https://mapbox.tuyen-vuduc.tech/",
+  "dotnet8": true,
   "runtimeDependenciesAsCompile": true
 }

--- a/src/android/com.mapbox.common/loader/0.11.0.json
+++ b/src/android/com.mapbox.common/loader/0.11.0.json
@@ -1,4 +1,5 @@
 {
-  "revision": 0,
+  "revision": 1,
+  "nugetVersion": "0.11.0.1",
   "runtimeDependenciesAsCompile": true
 }

--- a/src/android/com.mapbox.common/loader/nuget.json
+++ b/src/android/com.mapbox.common/loader/nuget.json
@@ -1,7 +1,7 @@
 {
   "packageId": "Com.Mapbox.Common.Loader",
   "name": "loader",
-  "dependencyOnly": true,
+  "dependencyOnly": false,
   "dotnet8": false,
   "versionMappings": []
 }

--- a/src/android/com.mapbox.common/logger/0.11.0.json
+++ b/src/android/com.mapbox.common/logger/0.11.0.json
@@ -1,4 +1,5 @@
 {
-  "revision": 0,
+  "revision": 1,
+  "nugetVersion": "0.11.0.1",
   "runtimeDependenciesAsCompile": true
 }

--- a/src/android/com.mapbox.common/logger/nuget.json
+++ b/src/android/com.mapbox.common/logger/nuget.json
@@ -1,7 +1,7 @@
 {
   "packageId": "Com.Mapbox.Common.Logger",
   "name": "logger",
-  "dependencyOnly": true,
+  "dependencyOnly": false,
   "dotnet8": false,
   "versionMappings": []
 }

--- a/src/android/com.mapbox.common/maven.props
+++ b/src/android/com.mapbox.common/maven.props
@@ -1,0 +1,27 @@
+<Project>
+  <ItemGroup>
+    <AndroidNamespaceReplacement Include='Com.Mapbox.Maps.Plugin' Replacement='Com.Mapbox.Maps.Plugins' Visible="false" />
+    <AndroidNamespaceReplacement Include='Com.Mapbox.Maps.Plugins.Attribution' Replacement='Com.Mapbox.Maps.Plugins.Attributions' Visible="false" />
+    <AndroidNamespaceReplacement Include='Com.Mapbox.Maps.Annotation' Replacement='Com.Mapbox.Maps.Annotations' Visible="false" />
+    <AndroidNamespaceReplacement Include='Com.Mapbox.Maps.Plugins.Annotation' Replacement='Com.Mapbox.Maps.Plugins.Annotations' Visible="false" />
+  </ItemGroup>    
+  <ItemGroup>
+    <GradleRepository Include="https://api.mapbox.com/downloads/v2/releases/maven">
+      <Repository>
+      maven {
+        url 'https://api.mapbox.com/downloads/v2/releases/maven'
+        authentication {
+          basic(BasicAuthentication)
+        }
+        credentials {
+          // Do not change the username below.
+          // This should always be `mapbox` (not your username).
+          username = "mapbox"
+          // Use the secret token you stored in gradle.properties as the password
+          password = providers.gradleProperty("MAPBOX_DOWNLOADS_TOKEN").get()
+        }
+      }
+      </Repository>
+    </GradleRepository>
+  </ItemGroup>
+</Project>

--- a/src/android/com.mapbox.extension/group.json
+++ b/src/android/com.mapbox.extension/group.json
@@ -2,5 +2,6 @@
   "name": "Mapbox",
   "homePageUrl": "https://docs.mapbox.com/android/maps/guides/",
   "guideUrl": "https://mapbox.tuyen-vuduc.tech/",
+  "dotnet8": true,
   "runtimeDependenciesAsCompile": true
 }

--- a/src/android/com.mapbox.extension/maps-style/11.3.1.fixed.json
+++ b/src/android/com.mapbox.extension/maps-style/11.3.1.fixed.json
@@ -1,0 +1,4 @@
+{
+    "Xamarin.Kotlin.StdLib": "1.9.23.1",
+    "Xamarin.AndroidX.Core.Core.Ktx": "1.13.0.1"
+}

--- a/src/android/com.mapbox.extension/maps-style/11.3.1.json
+++ b/src/android/com.mapbox.extension/maps-style/11.3.1.json
@@ -1,4 +1,5 @@
 {
-  "revision": 0,
+  "revision": 1,
+  "nugetVersion": "11.3.1.1",
   "runtimeDependenciesAsCompile": true
 }

--- a/src/android/com.mapbox.extension/maps-style/nuget.json
+++ b/src/android/com.mapbox.extension/maps-style/nuget.json
@@ -1,7 +1,7 @@
 {
   "packageId": "Com.Mapbox.Extension.MapsStyle",
   "name": "maps-style",
-  "dependencyOnly": true,
+  "dependencyOnly": false,
   "dotnet8": false,
   "versionMappings": []
 }

--- a/src/android/com.mapbox.extension/maven.props
+++ b/src/android/com.mapbox.extension/maven.props
@@ -1,0 +1,27 @@
+<Project>
+  <ItemGroup>
+    <AndroidNamespaceReplacement Include='Com.Mapbox.Maps.Plugin' Replacement='Com.Mapbox.Maps.Plugins' Visible="false" />
+    <AndroidNamespaceReplacement Include='Com.Mapbox.Maps.Plugins.Attribution' Replacement='Com.Mapbox.Maps.Plugins.Attributions' Visible="false" />
+    <AndroidNamespaceReplacement Include='Com.Mapbox.Maps.Annotation' Replacement='Com.Mapbox.Maps.Annotations' Visible="false" />
+    <AndroidNamespaceReplacement Include='Com.Mapbox.Maps.Plugins.Annotation' Replacement='Com.Mapbox.Maps.Plugins.Annotations' Visible="false" />
+  </ItemGroup>    
+  <ItemGroup>
+    <GradleRepository Include="https://api.mapbox.com/downloads/v2/releases/maven">
+      <Repository>
+      maven {
+        url 'https://api.mapbox.com/downloads/v2/releases/maven'
+        authentication {
+          basic(BasicAuthentication)
+        }
+        credentials {
+          // Do not change the username below.
+          // This should always be `mapbox` (not your username).
+          username = "mapbox"
+          // Use the secret token you stored in gradle.properties as the password
+          password = providers.gradleProperty("MAPBOX_DOWNLOADS_TOKEN").get()
+        }
+      }
+      </Repository>
+    </GradleRepository>
+  </ItemGroup>
+</Project>

--- a/src/android/com.mapbox.mapboxsdk/group.json
+++ b/src/android/com.mapbox.mapboxsdk/group.json
@@ -1,5 +1,7 @@
 {
   "name": "Mapbox",
   "homePageUrl": "https://docs.mapbox.com/android/maps/guides/",
-  "guideUrl": "https://mapbox.tuyen-vuduc.tech/"
+  "guideUrl": "https://mapbox.tuyen-vuduc.tech/",
+  "dotnet8": true,
+  "runtimeDependenciesAsCompile": true
 }

--- a/src/android/com.mapbox.mapboxsdk/mapbox-android-gestures/0.8.0.fixed.json
+++ b/src/android/com.mapbox.mapboxsdk/mapbox-android-gestures/0.8.0.fixed.json
@@ -1,0 +1,3 @@
+{
+    "Xamarin.AndroidX.Annotation": "1.3.0.3"
+}

--- a/src/android/com.mapbox.mapboxsdk/mapbox-android-gestures/0.8.0.json
+++ b/src/android/com.mapbox.mapboxsdk/mapbox-android-gestures/0.8.0.json
@@ -1,4 +1,5 @@
 {
-  "revision": 3,
+  "revision": 4,
+  "nugetVersion": "0.8.0.4",
   "runtimeDependenciesAsCompile": true
 }

--- a/src/android/com.mapbox.mapboxsdk/mapbox-android-gestures/nuget.json
+++ b/src/android/com.mapbox.mapboxsdk/mapbox-android-gestures/nuget.json
@@ -1,7 +1,7 @@
 {
   "packageId": "Com.Mapbox.Mapboxsdk.MapboxAndroidGestures",
   "name": "mapbox-android-gestures",
-  "dependencyOnly": true,
+  "dependencyOnly": false,
   "dotnet8": false,
   "versionMappings": []
 }

--- a/src/android/com.mapbox.mapboxsdk/mapbox-sdk-geojson/5.4.1.json
+++ b/src/android/com.mapbox.mapboxsdk/mapbox-sdk-geojson/5.4.1.json
@@ -1,3 +1,5 @@
 {
-  "fallbackVersion": "6.9.0"
+  "revision": 0,
+  "nugetVersion": "5.4.1",
+  "runtimeDependenciesAsCompile": true
 }

--- a/src/android/com.mapbox.mapboxsdk/mapbox-sdk-geojson/6.9.0.json
+++ b/src/android/com.mapbox.mapboxsdk/mapbox-sdk-geojson/6.9.0.json
@@ -1,4 +1,5 @@
 {
-  "revision": 3,
+  "revision": 4,
+  "nugetVersion": "6.9.0.4",
   "runtimeDependenciesAsCompile": true
 }

--- a/src/android/com.mapbox.mapboxsdk/mapbox-sdk-geojson/nuget.json
+++ b/src/android/com.mapbox.mapboxsdk/mapbox-sdk-geojson/nuget.json
@@ -1,7 +1,7 @@
 {
   "packageId": "Com.Mapbox.Mapboxsdk.MapboxSdkGeojson",
   "name": "mapbox-sdk-geojson",
-  "dependencyOnly": true,
+  "dependencyOnly": false,
   "dotnet8": false,
   "versionMappings": []
 }

--- a/src/android/com.mapbox.mapboxsdk/maven.props
+++ b/src/android/com.mapbox.mapboxsdk/maven.props
@@ -1,0 +1,27 @@
+<Project>
+  <ItemGroup>
+    <AndroidNamespaceReplacement Include='Com.Mapbox.Maps.Plugin' Replacement='Com.Mapbox.Maps.Plugins' Visible="false" />
+    <AndroidNamespaceReplacement Include='Com.Mapbox.Maps.Plugins.Attribution' Replacement='Com.Mapbox.Maps.Plugins.Attributions' Visible="false" />
+    <AndroidNamespaceReplacement Include='Com.Mapbox.Maps.Annotation' Replacement='Com.Mapbox.Maps.Annotations' Visible="false" />
+    <AndroidNamespaceReplacement Include='Com.Mapbox.Maps.Plugins.Annotation' Replacement='Com.Mapbox.Maps.Plugins.Annotations' Visible="false" />
+  </ItemGroup>    
+  <ItemGroup>
+    <GradleRepository Include="https://api.mapbox.com/downloads/v2/releases/maven">
+      <Repository>
+      maven {
+        url 'https://api.mapbox.com/downloads/v2/releases/maven'
+        authentication {
+          basic(BasicAuthentication)
+        }
+        credentials {
+          // Do not change the username below.
+          // This should always be `mapbox` (not your username).
+          username = "mapbox"
+          // Use the secret token you stored in gradle.properties as the password
+          password = providers.gradleProperty("MAPBOX_DOWNLOADS_TOKEN").get()
+        }
+      }
+      </Repository>
+    </GradleRepository>
+  </ItemGroup>
+</Project>

--- a/src/android/com.mapbox.maps/android-core/11.3.2.fixed.json
+++ b/src/android/com.mapbox.maps/android-core/11.3.2.fixed.json
@@ -1,5 +1,5 @@
 {
-  "Xamarin.KotlinX.Coroutines.Core.Jvm": "1.6.4.3",
-  "Xamarin.AndroidX.Annotation": "1.7.1.1",
-  "Xamarin.Kotlin.StdLib.Common": "1.9.10.2"
+  "Xamarin.KotlinX.Coroutines.Core.Jvm": "1.7.3.3",
+  "Xamarin.AndroidX.Annotation": "1.7.1.2",
+  "Xamarin.Kotlin.StdLib.Common": "1.9.21.1"
 }

--- a/src/android/com.mapbox.maps/android-core/11.3.2.json
+++ b/src/android/com.mapbox.maps/android-core/11.3.2.json
@@ -1,4 +1,5 @@
 {
-  "revision": 0,
+  "revision": 1,
+  "nugetVersion": "11.3.2.1",
   "runtimeDependenciesAsCompile": true
 }

--- a/src/android/com.mapbox.maps/android-core/nuget.json
+++ b/src/android/com.mapbox.maps/android-core/nuget.json
@@ -1,7 +1,7 @@
 {
   "packageId": "Com.Mapbox.Maps.AndroidCore",
   "name": "android-core",
-  "dependencyOnly": true,
+  "dependencyOnly": false,
   "dotnet8": false,
   "versionMappings": []
 }

--- a/src/android/com.mapbox.maps/android/11.3.1.fixed.json
+++ b/src/android/com.mapbox.maps/android/11.3.1.fixed.json
@@ -1,0 +1,3 @@
+{
+    "Xamarin.KotlinX.Coroutines.Core": "1.8.0.2"
+}

--- a/src/android/com.mapbox.maps/android/11.3.1.json
+++ b/src/android/com.mapbox.maps/android/11.3.1.json
@@ -1,4 +1,5 @@
 {
-  "revision": 0,
+  "revision": 1,
+  "nugetVersion": "11.3.1.1",
   "runtimeDependenciesAsCompile": true
 }

--- a/src/android/com.mapbox.maps/base/11.3.1.fixed.json
+++ b/src/android/com.mapbox.maps/base/11.3.1.fixed.json
@@ -1,0 +1,4 @@
+{
+    "Xamarin.Kotlin.StdLib.Common": "1.9.21.1",
+    "Xamarin.AndroidX.Annotation": "1.7.1.2"
+}

--- a/src/android/com.mapbox.maps/base/11.3.1.json
+++ b/src/android/com.mapbox.maps/base/11.3.1.json
@@ -1,4 +1,5 @@
 {
-  "revision": 0,
+  "revision": 1,
+  "nugetVersion": "11.3.1.1",
   "runtimeDependenciesAsCompile": true
 }

--- a/src/android/com.mapbox.maps/base/binding/Transforms/Metadata.xml
+++ b/src/android/com.mapbox.maps/base/binding/Transforms/Metadata.xml
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-	 <remove-node
+	<remove-node
 		path="/api/package[@name='com.mapbox.maps.extension.style']/interface[@name='StyleInterface']/implements[@name='com.mapbox.maps.StyleManagerInterface']" /> 
+	<!-- <remove-node path="/api/package[@name='com.mapbox.maps.plugin.annotation']/interface[@name='OnAnnotationClickListener']/method[@name='onAnnotationClick' and count(parameter)=1 and parameter[1][@type='T']]" /> -->
 </metadata>

--- a/src/android/com.mapbox.maps/base/nuget.json
+++ b/src/android/com.mapbox.maps/base/nuget.json
@@ -1,7 +1,7 @@
 {
   "packageId": "Com.Mapbox.Maps.Base",
   "name": "base",
-  "dependencyOnly": true,
+  "dependencyOnly": false,
   "dotnet8": false,
   "versionMappings": []
 }

--- a/src/android/com.mapbox.maps/group.json
+++ b/src/android/com.mapbox.maps/group.json
@@ -2,5 +2,6 @@
   "name": "Mapbox",
   "homePageUrl": "https://docs.mapbox.com/android/maps/guides/",
   "guideUrl": "https://mapbox.tuyen-vuduc.tech/",
+  "dotnet8": true,
   "runtimeDependenciesAsCompile": true
 }

--- a/src/android/com.mapbox.module/group.json
+++ b/src/android/com.mapbox.module/group.json
@@ -1,5 +1,7 @@
 {
   "name": "Mapbox",
   "homePageUrl": "https://docs.mapbox.com/android/maps/guides/",
-  "guideUrl": "https://mapbox.tuyen-vuduc.tech/"
+  "guideUrl": "https://mapbox.tuyen-vuduc.tech/",
+  "dotnet8": false,
+  "runtimeDependenciesAsCompile": true
 }

--- a/src/android/com.mapbox.module/maven.props
+++ b/src/android/com.mapbox.module/maven.props
@@ -1,0 +1,27 @@
+<Project>
+  <ItemGroup>
+    <AndroidNamespaceReplacement Include='Com.Mapbox.Maps.Plugin' Replacement='Com.Mapbox.Maps.Plugins' Visible="false" />
+    <AndroidNamespaceReplacement Include='Com.Mapbox.Maps.Plugins.Attribution' Replacement='Com.Mapbox.Maps.Plugins.Attributions' Visible="false" />
+    <AndroidNamespaceReplacement Include='Com.Mapbox.Maps.Annotation' Replacement='Com.Mapbox.Maps.Annotations' Visible="false" />
+    <AndroidNamespaceReplacement Include='Com.Mapbox.Maps.Plugins.Annotation' Replacement='Com.Mapbox.Maps.Plugins.Annotations' Visible="false" />
+  </ItemGroup>    
+  <ItemGroup>
+    <GradleRepository Include="https://api.mapbox.com/downloads/v2/releases/maven">
+      <Repository>
+      maven {
+        url 'https://api.mapbox.com/downloads/v2/releases/maven'
+        authentication {
+          basic(BasicAuthentication)
+        }
+        credentials {
+          // Do not change the username below.
+          // This should always be `mapbox` (not your username).
+          username = "mapbox"
+          // Use the secret token you stored in gradle.properties as the password
+          password = providers.gradleProperty("MAPBOX_DOWNLOADS_TOKEN").get()
+        }
+      }
+      </Repository>
+    </GradleRepository>
+  </ItemGroup>
+</Project>

--- a/src/android/com.mapbox.plugin/group.json
+++ b/src/android/com.mapbox.plugin/group.json
@@ -1,5 +1,7 @@
 {
   "name": "Mapbox",
   "homePageUrl": "https://docs.mapbox.com/android/maps/guides/",
-  "guideUrl": "https://mapbox.tuyen-vuduc.tech/"
+  "guideUrl": "https://mapbox.tuyen-vuduc.tech/",
+  "dotnet8": true,
+  "runtimeDependenciesAsCompile": true
 }

--- a/src/android/com.mapbox.plugin/maps-annotation/11.3.1.fixed.json
+++ b/src/android/com.mapbox.plugin/maps-annotation/11.3.1.fixed.json
@@ -1,0 +1,5 @@
+{
+    "Xamarin.AndroidX.Annotation": "1.7.1.2",
+    "Xamarin.AndroidX.Core.Core.Ktx": "1.13.0.1",
+    "Xamarin.Kotlin.StdLib.Jdk8": "1.9.21.1"
+}

--- a/src/android/com.mapbox.plugin/maps-annotation/11.3.1.json
+++ b/src/android/com.mapbox.plugin/maps-annotation/11.3.1.json
@@ -1,4 +1,5 @@
 {
-  "revision": 0,
+  "revision": 1,
+  "nugetVersion": "11.3.1.1",
   "runtimeDependenciesAsCompile": true
 }

--- a/src/android/com.mapbox.plugin/maps-annotation/binding/Transforms/Metadata.xml
+++ b/src/android/com.mapbox.plugin/maps-annotation/binding/Transforms/Metadata.xml
@@ -15,4 +15,25 @@
 	<attr
 		path="/api/package[@name='com.mapbox.maps.plugin.annotation.generated']/class[substring(@name, string-length(@name) - string-length('AnnotationManager') + 1)]/method[@name='createDragLayer' and count(parameter)=0]"
 		name="managedName">DoCreateDragLayer</attr>
+	<remove-node path="//implements[@name='com.mapbox.maps.plugin.annotation.OnAnnotationClickListener']" />
+	<add-node path="/api/package[@name='com.mapbox.maps.plugin.annotation.generated']/interface[@name='OnCircleAnnotationClickListener']">
+		<method abstract="true" deprecated="not deprecated" final="false" name="onAnnotationClick" jni-signature="(LLcom/mapbox/maps/plugin/annotation/generated/CircleAnnotation;)Z" bridge="false" native="false" return="boolean" jni-return="Z" static="false" synchronized="false" synthetic="false" visibility="public">
+			<parameter name="annotation" type="com.mapbox.maps.plugin.annotation.generated.CircleAnnotation" jni-type="Lcom/mapbox/maps/plugin/annotation/generated/CircleAnnotation;" not-null="true" />
+		</method>
+	</add-node>
+	<add-node path="/api/package[@name='com.mapbox.maps.plugin.annotation.generated']/interface[@name='OnPointAnnotationClickListener']">
+		<method abstract="true" deprecated="not deprecated" final="false" name="onAnnotationClick" jni-signature="(Lcom/mapbox/maps/plugin/annotation/generated/PointAnnotation;)Z" bridge="false" native="false" return="boolean" jni-return="Z" static="false" synchronized="false" synthetic="false" visibility="public">
+			<parameter name="annotation" type="com.mapbox.maps.plugin.annotation.generated.PointAnnotation" jni-type="Lcom/mapbox/maps/plugin/annotation/generated/PointAnnotation;" not-null="true" />
+		</method>
+	</add-node>
+	<add-node path="/api/package[@name='com.mapbox.maps.plugin.annotation.generated']/interface[@name='OnPolygonAnnotationClickListener']">
+		<method abstract="true" deprecated="not deprecated" final="false" name="onAnnotationClick" jni-signature="(Lcom/mapbox/maps/plugin/annotation/generated/PolygonAnnotation;)Z" bridge="false" native="false" return="boolean" jni-return="Z" static="false" synchronized="false" synthetic="false" visibility="public">
+			<parameter name="annotation" type="com.mapbox.maps.plugin.annotation.generated.PolygonAnnotation" jni-type="Lcom/mapbox/maps/plugin/annotation/generated/PolygonAnnotation;" not-null="true" />
+		</method>
+	</add-node>
+	<add-node path="/api/package[@name='com.mapbox.maps.plugin.annotation.generated']/interface[@name='OnPolylineAnnotationClickListener']">
+		<method abstract="true" deprecated="not deprecated" final="false" name="onAnnotationClick" jni-signature="(Lcom/mapbox/maps/plugin/annotation/generated/PolylineAnnotation;)Z" bridge="false" native="false" return="boolean" jni-return="Z" static="false" synchronized="false" synthetic="false" visibility="public">
+			<parameter name="annotation" type="com.mapbox.maps.plugin.annotation.generated.PolylineAnnotation" jni-type="Lcom/mapbox/maps/plugin/annotation/generated/PolylineAnnotation;" not-null="true" />
+		</method>
+	</add-node>
 </metadata>

--- a/src/android/com.mapbox.plugin/maps-annotation/nuget.json
+++ b/src/android/com.mapbox.plugin/maps-annotation/nuget.json
@@ -1,7 +1,7 @@
 {
   "packageId": "Com.Mapbox.Plugin.MapsAnnotation",
   "name": "maps-annotation",
-  "dependencyOnly": true,
+  "dependencyOnly": false,
   "dotnet8": false,
   "versionMappings": []
 }

--- a/src/android/com.mapbox.plugin/maven.props
+++ b/src/android/com.mapbox.plugin/maven.props
@@ -1,0 +1,27 @@
+<Project>
+  <ItemGroup>
+    <AndroidNamespaceReplacement Include='Com.Mapbox.Maps.Plugin' Replacement='Com.Mapbox.Maps.Plugins' Visible="false" />
+    <AndroidNamespaceReplacement Include='Com.Mapbox.Maps.Plugins.Attribution' Replacement='Com.Mapbox.Maps.Plugins.Attributions' Visible="false" />
+    <AndroidNamespaceReplacement Include='Com.Mapbox.Maps.Annotation' Replacement='Com.Mapbox.Maps.Annotations' Visible="false" />
+    <AndroidNamespaceReplacement Include='Com.Mapbox.Maps.Plugins.Annotation' Replacement='Com.Mapbox.Maps.Plugins.Annotations' Visible="false" />
+  </ItemGroup>    
+  <ItemGroup>
+    <GradleRepository Include="https://api.mapbox.com/downloads/v2/releases/maven">
+      <Repository>
+      maven {
+        url 'https://api.mapbox.com/downloads/v2/releases/maven'
+        authentication {
+          basic(BasicAuthentication)
+        }
+        credentials {
+          // Do not change the username below.
+          // This should always be `mapbox` (not your username).
+          username = "mapbox"
+          // Use the secret token you stored in gradle.properties as the password
+          password = providers.gradleProperty("MAPBOX_DOWNLOADS_TOKEN").get()
+        }
+      }
+      </Repository>
+    </GradleRepository>
+  </ItemGroup>
+</Project>

--- a/src/android/com.squareup.okhttp3/group.json
+++ b/src/android/com.squareup.okhttp3/group.json
@@ -1,4 +1,5 @@
 {
   "name": "com.squareup.okhttp3",
-  "dotnet8": false
+  "dotnet8": false,
+  "runtimeDependenciesAsCompile": true
 }

--- a/src/android/org.jetbrains.kotlinx/group.json
+++ b/src/android/org.jetbrains.kotlinx/group.json
@@ -1,4 +1,5 @@
 {
   "name": "org.jetbrains.kotlinx",
-  "dotnet8": false
+  "dotnet8": false,
+  "runtimeDependenciesAsCompile": true
 }

--- a/src/libs/Binderator.Gradle/Model/ArtifactModel.cs
+++ b/src/libs/Binderator.Gradle/Model/ArtifactModel.cs
@@ -40,7 +40,12 @@ public class ArtifactModel : IEquatable<ArtifactModel>
         ? ShadowArtifact.LibRelativePath
         : IsAAR
         ? Files?.FirstOrDefault(x => !x.Contains("_aar") && x.EndsWith(".aar"))?.Replace("\\", "/")
-        : Files?.FirstOrDefault(x => !x.Contains("_aar") && x.EndsWith(".jar"))?.Replace("\\", "/");
+        : Files?.FirstOrDefault(
+            x => !x.Contains("_aar") 
+            && !x.Contains("-sources") 
+            && !x.Contains("-javadoc") 
+            && x.EndsWith(".jar"))
+        ?.Replace("\\", "/");
     public string SourcesJarRelativeFilePath => ShadowArtifact != null
         ? ShadowArtifact.SourcesJarRelativeFilePath
         : Files?.FirstOrDefault(x => x.EndsWith("-sources.jar"));

--- a/src/libs/Binderator.Gradle/Util.cs
+++ b/src/libs/Binderator.Gradle/Util.cs
@@ -1,3 +1,5 @@
+#nullable restore
+
 using System.Text;
 using System.Security.Cryptography;
 using System.Text.Json.Serialization;


### PR DESCRIPTION
- .NET8 as default
- Fix wrong major version jump: Caused child binding libraries failed to build (mapbox-sdk-geojson from 5.4.1 to 6.9.0)
- Fix hierarchical generic interface inheritance: Caused wrong Java class generation when using in actual application (IOnAnnotationClickListener, IOnPointAnnotationClickListener)