### PR TITLE
Enable Setup Intent on iOS

### DIFF
--- a/src/ios/Stripe/TVStripePaymentSheet.iOS/ApiDefinitions.cs
+++ b/src/ios/Stripe/TVStripePaymentSheet.iOS/ApiDefinitions.cs
@@ -387,9 +387,9 @@ namespace TVStripePaymentSheet
 		[Export ("initWithPaymentIntentClientSecret:configuration:")]
 		NativeHandle Constructor (string paymentIntentClientSecret, TSPSConfiguration configuration);
 
-		// // -(instancetype _Nonnull)initWithSetupIntentClientSecret:(NSString * _Nonnull)setupIntentClientSecret configuration:(TSPSConfiguration * _Nonnull)configuration;
-		// [Export ("initWithSetupIntentClientSecret:configuration:")]
-		// NativeHandle Constructor (string setupIntentClientSecret, TSPSConfiguration configuration);
+        // -(instancetype _Nonnull)initWithSetupIntentClientSecret:(NSString * _Nonnull)setupIntentClientSecret configuration:(TSPSConfiguration * _Nonnull)configuration differentiator:(NSString * _Nonnull)differentiator;
+        [Export ("initWithSetupIntentClientSecret:configuration:differentiator:")]
+		NativeHandle Constructor (string setupIntentClientSecret, TSPSConfiguration configuration, string differentiator);
 
 		// +(void)resetCustomer;
 		[Static]

--- a/src/ios/Stripe/adapters/StripePaymentsheetObjC/TVStripePaymentSheet/TSPSPaymentSheet.swift
+++ b/src/ios/Stripe/adapters/StripePaymentsheetObjC/TVStripePaymentSheet/TSPSPaymentSheet.swift
@@ -30,7 +30,7 @@ public class TSPSPaymentSheet : NSObject {
     /// Initializes a PaymentSheet
     /// - Parameter setupIntentClientSecret: The [client secret](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-client_secret) of a Stripe SetupIntent object
     /// - Parameter configuration: Configuration for the PaymentSheet. e.g. your business name, Customer details, etc.
-    @objc public convenience init(setupIntentClientSecret: String, configuration:TSPSConfiguration) {
+    @objc public convenience init(setupIntentClientSecret: String, configuration:TSPSConfiguration, differentiator: String) {
         self.init()
         
         origin = PaymentSheet(

--- a/src/ios/Stripe/artifacts/TVStripePaymentSheet.xcframework/ios-arm64/TVStripePaymentSheet.framework/Headers/TVStripePaymentSheet-Swift.h
+++ b/src/ios/Stripe/artifacts/TVStripePaymentSheet.xcframework/ios-arm64/TVStripePaymentSheet.framework/Headers/TVStripePaymentSheet-Swift.h
@@ -745,7 +745,7 @@ SWIFT_CLASS_NAMED("TSPSPaymentSheet")
 ///
 /// \param configuration Configuration for the PaymentSheet. e.g. your business name, Customer details, etc.
 ///
-- (nonnull instancetype)initWithSetupIntentClientSecret:(NSString * _Nonnull)setupIntentClientSecret configuration:(TSPSConfiguration * _Nonnull)configuration;
+- (nonnull instancetype)initWithSetupIntentClientSecret:(NSString * _Nonnull)setupIntentClientSecret configuration:(TSPSConfiguration * _Nonnull)configuration differentiator:(NSString * _Nonnull)differentiator;
 + (void)resetCustomer;
 /// Presents a sheet for a customer to complete their payment
 /// \param presentingViewController The view controller to present a payment sheet


### PR DESCRIPTION
Hack to enable setup intent on iOS since the iOS sdk specifies two constructors with the same parameters which is invalid in c#